### PR TITLE
Potential fix for code scanning alert no. 32: Server-side request forgery

### DIFF
--- a/features/quickstart/lib/fetchLanguages.ts
+++ b/features/quickstart/lib/fetchLanguages.ts
@@ -6,7 +6,19 @@ export const fetchLanguages = async (
 ): Promise<string[] | null> => {
   if (!languagesUrl) return null;
 
+  // Validate that languagesUrl is a GitHub API languages endpoint
   try {
+    const urlObj = new URL(languagesUrl);
+    // Only allow https://api.github.com/repos/{owner}/{repo}/languages
+    if (
+      urlObj.protocol !== 'https:' ||
+      urlObj.hostname !== 'api.github.com' ||
+      !/^\/repos\/[^\/]+\/[^\/]+\/languages$/.test(urlObj.pathname)
+    ) {
+      console.error('Invalid languagesUrl:', languagesUrl);
+      return null;
+    }
+
     const response = await axios.get(languagesUrl);
     const data: { [key: string]: number } = response.data;
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/32](https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/32)

To fix the SSRF vulnerability, we should restrict the URLs that can be used in the outgoing request. The best approach is to validate that `languagesUrl` is a GitHub API endpoint, specifically matching the expected pattern for repository language breakdown URLs (e.g., `https://api.github.com/repos/{owner}/{repo}/languages`). This can be done by parsing the URL and checking that the hostname is exactly `api.github.com` and the path matches the expected format. If the URL does not pass validation, the function should return `null` or throw an error, and not make the request.

The required changes are in `features/quickstart/lib/fetchLanguages.ts`, specifically in the `fetchLanguages` function. We will:
- Add a check to ensure `languagesUrl` is a valid GitHub API languages endpoint.
- Only proceed with the request if the check passes.
- Optionally, log or handle invalid URLs.

No changes are needed in other files based on the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
