### PR TITLE
Potential fix for code scanning alert no. 7: Use of externally-controlled format string

### DIFF
--- a/lib/github.ts
+++ b/lib/github.ts
@@ -9,7 +9,7 @@ export async function getGithubProfileData(username: string) {
     const response = await octokit.users.getByUsername({ username });
     return response.data;
   } catch (error) {
-    console.error(`Failed to get GitHub data for ${username}`, error);
+    console.error('Failed to get GitHub data for %s', username, error);
     return null;
   }
 }
@@ -27,7 +27,7 @@ export async function getGithubReposWithUsername(username: string) {
 
     return response.data;
   } catch (error) {
-    console.error(`Failed to get GitHub data for ${username}`, error);
+    console.error('Failed to get GitHub data for %s', username, error);
     return null;
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/7](https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/7)

To fix the problem, we should avoid passing user-controlled data directly in a format string to `console.error`. Instead, we should use a static format string with a `%s` placeholder and pass the untrusted data as a separate argument. This ensures that any format specifiers in the user input are treated as literal strings and do not affect the formatting of the log message. Specifically, in `lib/github.ts`, on line 12, change:

```ts
console.error(`Failed to get GitHub data for ${username}`, error);
```

to

```ts
console.error('Failed to get GitHub data for %s', username, error);
```

This change should be made in both error logging statements in the file, as the same pattern is used on line 30 in the second function.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
