### PR TITLE
Fix for code scanning - fetchLanguages in Quickstart flow

### DIFF
--- a/features/quickstart/hooks/useQuickstartSetup.ts
+++ b/features/quickstart/hooks/useQuickstartSetup.ts
@@ -243,7 +243,7 @@ export function useQuickstartSetup() {
         .filter((repo) => selectedRepos.includes(repo.id.toString()))
         .map(async (repo) => {
           const readme = await fetchReadme(username, repo.name);
-          const languages = await fetchLanguages(repo.languages_url);
+          const languages = await fetchLanguages(username, repo.name);
           return {
             reponame_lowercase: repo?.name.toLowerCase(),
             ...repo,

--- a/features/quickstart/lib/fetchLanguages.ts
+++ b/features/quickstart/lib/fetchLanguages.ts
@@ -1,24 +1,14 @@
 import axios from 'axios';
 
 // Utility function to fetch language breakdown usage in repo and return as an array of string with language and percentage
+// Accept owner and repo, construct the URL internally to prevent SSRF
 export const fetchLanguages = async (
-  languagesUrl?: string | null
+  owner: string,
+  repo: string
 ): Promise<string[] | null> => {
-  if (!languagesUrl) return null;
-
-  // Validate that languagesUrl is a GitHub API languages endpoint
+  if (!owner || !repo) return null;
   try {
-    const urlObj = new URL(languagesUrl);
-    // Only allow https://api.github.com/repos/{owner}/{repo}/languages
-    if (
-      urlObj.protocol !== 'https:' ||
-      urlObj.hostname !== 'api.github.com' ||
-      !/^\/repos\/[^\/]+\/[^\/]+\/languages$/.test(urlObj.pathname)
-    ) {
-      console.error('Invalid languagesUrl:', languagesUrl);
-      return null;
-    }
-
+    const languagesUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/languages`;
     const response = await axios.get(languagesUrl);
     const data: { [key: string]: number } = response.data;
 

--- a/features/quickstart/lib/saveQuickstart.ts
+++ b/features/quickstart/lib/saveQuickstart.ts
@@ -24,7 +24,7 @@ export async function saveQuickstartProject(
     // Run extra server functions for readme and languages etc:
 
     const readme = await fetchReadmeNoapi(userName, repoName);
-    const languages = await fetchLanguages(projectData.languages_url);
+    const languages = await fetchLanguages(userName, repoName);
 
     const parentDocRef = doc(db, `usersAnonymous/${userid}/reposAnonymous/${repoid}`);
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/32](https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/32)

To fully mitigate SSRF, do not accept a full URL from the user. Instead, require only the trusted parameters (e.g., `owner` and `repo`), and construct the GitHub languages API URL server-side. This ensures the hostname and path are always correct and cannot be manipulated by the user. 

**Steps:**
- In `saveQuickstartProject`, pass `userName` and `repoName` to `fetchLanguages` instead of `projectData.languages_url`.
- Refactor `fetchLanguages` to accept `owner` and `repo` as arguments, and construct the URL internally.
- Remove the validation logic, as the URL will always be safe.
- Update all calls to `fetchLanguages` accordingly.

**Required changes:**
- In `features/quickstart/lib/fetchLanguages.ts`: Change the function signature to accept `owner` and `repo`, and construct the URL.
- In `features/quickstart/lib/saveQuickstart.ts`: Update the call to `fetchLanguages` to pass `userName` and `repoName`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
