### PR TITLE
Image convert path - restrict allowed URL inputs

### DIFF
--- a/pages/api/image/convert.ts
+++ b/pages/api/image/convert.ts
@@ -20,9 +20,18 @@ export default async function handler(
       throw new Error('Invalid imageUrl');
     }
     parsedUrl = new URL(imageUrl);
+    const ALLOWED_HOSTS = ['firebasestorage.googleapis.com'];
+    // Check exact hostname match after normalisation
+    const normalisedHost = parsedUrl.hostname.replace(/\.$/, '').toLowerCase();
+    // Prevent credentials, ports, or suspicious paths
     if (
       parsedUrl.protocol !== 'https:' ||
-      parsedUrl.hostname !== 'firebasestorage.googleapis.com'
+      !ALLOWED_HOSTS.includes(normalisedHost) ||
+      parsedUrl.port || 
+      parsedUrl.username || 
+      parsedUrl.password || 
+      // Disallow path traversal
+      parsedUrl.pathname.includes('..')
     ) {
       throw new Error('Invalid imageUrl');
     }


### PR DESCRIPTION
Strictly validate the `imageUrl` parameter to avoid any potential misuse of convert path

- Parse the URL using the `URL` constructor.
- Ensure the protocol is `https:`.
- Ensure the hostname is exactly `firebasestorage.googleapis.com`.
- Optionally, check that the pathname matches expected patterns (if needed).
- Reject any URLs that do not meet these criteria.

No new methods are needed, but we will use the built-in `URL` class for parsing.

---

Fix for [Scan](https://github.com/Dannydoesdev/GitConnect-v2/security/code-scanning/33)
